### PR TITLE
Transform passed code instead of file content

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,43 @@
-import {Plugin} from "rollup";
-import * as fs from "fs";
+import { Plugin } from "rollup";
 import * as path from "path";
-const brfs = require('brfs');
+import { Readable } from "stream";
+
+const brfs = require("brfs");
 const EXTENSIONS = [".js", ".jsx", ".ts", ".tsx"];
 export type rollupBrfsOptions = {
     // Default:  [".js", ".jsx", ".ts", ".tsx"]
-    extensions?: string[]
+    extensions?: string[];
     // https://github.com/browserify/brfs#var-tr--brfsfile-opts
-    brfsOptions?: {}
-}
+    brfsOptions?: {};
+};
 const rollupBrfs = function rollUpBrfs(options: rollupBrfsOptions = {}): Plugin {
     return {
-        name: 'brfs',
-        transform(_code: string, id: string) {
+        name: "brfs",
+        transform(code: string, id: string) {
             const ext = path.extname(id);
             if (!EXTENSIONS.includes(ext)) {
                 return null;
             }
             return new Promise((resolve, reject) => {
                 let output: string = "";
-                const stream = fs.createReadStream(id)
-                    .pipe(brfs(id, options));
-                stream.on('data', function (data: string) {
+                const src = new Readable();
+                src.push(code);
+                src.push(null);
+                const stream = src.pipe(brfs(id, options));
+                stream.on("data", function(data: string) {
                     output += data.toString();
                 });
-                stream.on('end', function () {
+                stream.on("end", function() {
                     resolve({
                         code: output,
-                        map: {mappings: ''}
-                    })
+                        map: { mappings: "" }
+                    });
                 });
-                stream.on('error', function (error: Error) {
+                stream.on("error", function(error: Error) {
                     reject(error);
                 });
-            })
+            });
         }
-    }
+    };
 };
 export default rollupBrfs;


### PR DESCRIPTION
Read code to be transformed from code passed to `transform` method instead of from file directly

This allows to use this plugin together with/after other plugins like rollup-babel

BTW: the code style changes were done by prettier script